### PR TITLE
Create ResourceObserver

### DIFF
--- a/src/main/java/capslock/capslock/main/CapsLock.java
+++ b/src/main/java/capslock/capslock/main/CapsLock.java
@@ -40,6 +40,7 @@ public final class CapsLock extends Application {
 	private static final Path CONFIG_FILE = Paths.get("./config.properties");
     private static final ExecutorService executor = Executors.newWorkStealingPool();
 
+
     /**
      * デフォルトのエントリポイント.
      * 別アプリケーションからこのプログラムを起動するときは{@link CapsLock#InjectionPoint}から起動する.
@@ -71,6 +72,7 @@ public final class CapsLock extends Application {
 
         Logger.INST.info("CapsLock started.");
 
+
         if(System.getProperty("java.library.path").contains("dependentBinary")){
             Logger.INST.debug("It can be launched by Gradle");
         }else{
@@ -80,6 +82,7 @@ public final class CapsLock extends Application {
         MainHandler.INST.loadJSONDB();
 
         launch();
+
 
         Logger.INST.info("CapsLock terminated.");
         Logger.INST.flush();
@@ -110,6 +113,9 @@ public final class CapsLock extends Application {
 
 
         try {
+            final ResourceObserver resourceObserver=new ResourceObserver();
+            resourceObserver.Launch();
+            
             final MainFormController controller = loader.getController();
 
             MainHandler.INST.setController(controller);

--- a/src/main/java/capslock/capslock/main/ResourceObserver.java
+++ b/src/main/java/capslock/capslock/main/ResourceObserver.java
@@ -1,0 +1,58 @@
+package capslock.capslock.main;
+
+import com.sun.management.OperatingSystemMXBean;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.util.Duration;
+import methg.commonlib.trivial_logger.Logger;
+
+import javax.management.MBeanServerConnection;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+
+///<summary>
+///It observe cpu utilization rate and memory utilization rate with MBean in javax.management.MBeanServerConnection.
+///Rates provided by this class are approximate value because entrust MBean,so you should be careful.
+///</summary>
+
+public class ResourceObserver {
+
+    private final float interval_ms=60000;
+
+    private OperatingSystemMXBean osMBean;
+
+
+    public ResourceObserver(){
+        try{
+            MBeanServerConnection mbsc = ManagementFactory.getPlatformMBeanServer();
+            osMBean = ManagementFactory.newPlatformMXBeanProxy(
+                    mbsc, ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, OperatingSystemMXBean.class);
+        }catch (IOException e){
+            Logger.INST.logException(e);
+        }
+    }
+
+    public void Launch(){
+        final Timeline timer = new Timeline(new KeyFrame(Duration.millis(interval_ms), event -> OutPutLog()));
+        timer.setCycleCount(Timeline.INDEFINITE);
+        timer.play();
+    }
+
+    private void OutPutLog(){
+        Logger.INST.info(GetUsageCpuPersent()+","+GetUsageMemoryPersent());
+    }
+
+    private String GetUsageCpuPersent(){
+        final long percent=(long) (osMBean.getSystemCpuLoad()*100);
+
+        return "Cpu usage: "+percent+"%";
+    }
+
+    private String GetUsageMemoryPersent(){
+        final long totalmemory=osMBean.getTotalPhysicalMemorySize();
+        final long usingmemory=totalmemory-osMBean.getFreePhysicalMemorySize();
+        final long persent=(long)((double)usingmemory/totalmemory*100);
+
+        return "Memory usage: "+persent+"%";
+    }
+}


### PR DESCRIPTION
CPU使用率とメモリ使用率を1分ごとに監視しCapsLock.logに書き込む。ユーザランド領域の取得がとりあえず見つからなかったのでメモリ使用率は「使用中RAM量 / 全物理RAM量」で実装しています。
どうも誤差が結構あるようで軽く動かしたところ、CPUメモリ共に±5%ほど誤差が生じてしまっています。